### PR TITLE
Fix: Filter out null entries from frontmatter.urls and frontmatter.hubs to prevent conversion errors

### DIFF
--- a/src/uploadToNotion.js
+++ b/src/uploadToNotion.js
@@ -100,6 +100,8 @@ async function createMarkdownPage(title, date, text, frontmatter, databaseId, ma
   }
   if (removeFirstHeading(text).trim().startsWith("#")) insertUrlSpace = false;
   if (frontmatter.urls) {
+    // similar to hubs, we need to filter if the urls array have null entires to prevent code from throwing out errors
+    frontmatter.urls = frontmatter.urls.filter(url => url)
     if (frontmatter.urls.length > 0) {
       if (insertUrlSpace) {
         blocks.unshift({
@@ -148,6 +150,9 @@ async function createMarkdownPage(title, date, text, frontmatter, databaseId, ma
   }
 
   if (frontmatter.hubs) {
+    // if we have hubs as a title on the frontmatter and don't actually have any data inserted, there appears to be a case when frontmatter.hubs returns array of null values like [null]
+    // to fix this we can filter through those values and return only those which are not null
+    frontmatter.hubs = frontmatter.hubs.filter(hub => hub)
     if (frontmatter.hubs.length > 0) {
       properties['Tags'] = {
         multi_select: frontmatter.hubs.map(hub => ({ name: stripObsidianLink(hub) })),


### PR DESCRIPTION
## Description

When using Obsidian templates, the frontmatter may initialize urls and hubs as empty array items, for example:
```
---
date: {{date}}
tags:
    -
urls:
    -
hubs:
    -
---
```

This results in parsed values like:

```
frontmatter.urls = [null]
frontmatter.hubs = [null]
```

These null entries cause errors during the conversion of Obsidian markdown files to Notion blocks, breaking the process.

## Fix

Added filtering logic to remove null entries from both arrays:
```
frontmatter.urls = frontmatter.urls.filter(url => url)
frontmatter.hubs = frontmatter.hubs.filter(hub => hub)
```

This ensures that only valid entries remain in the arrays and prevents runtime errors during conversion.